### PR TITLE
Refactor InferenceModel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 Fast Dynamic Batcher
 ====================
 
-The bundling of several machine learning model inputs into a single larger input is the simplest way to achieve
+Bundling several ML model inputs into a larger batch is the simplest way to achieve
 significant inference speed-ups in ML workloads. The **Fast Dynamic Batcher** library has
 been built to make it easy to use such dynamic batches in Python web frameworks like FastAPI. With our
 dynamic batcher, you can combine the inputs of several requests into a
@@ -20,7 +20,7 @@ model in its ``init`` method and use it in its ``infer`` method:
 
 .. code-block:: python
 
-   from fast_dynamic_batcher.dyn_batcher import Task
+   from typing import Any
    from fast_dynamic_batcher.inference_template import InferenceModel
 
 
@@ -29,15 +29,10 @@ model in its ``init`` method and use it in its ``infer`` method:
           super().__init__()
           # Initiate your ML model here
 
-      def infer(self, tasks: list[Task]) -> list[Task]:
-          # Process your input tasks
-          inputs = [t.content for t in tasks]
+      def infer(self, inputs: list[Any]) -> list[Any]:
           # Run your inputs as a batch for your model
-          ml_output = None # Your inference outputs
-          results = [
-              Task(id=tasks[i].id, content=ml_output[i]) for i in range(len(tasks))
-          ]
-          return results
+          ml_output = ... # Your inference outputs
+          return ml_output
 
 Subsequently, use your ``InferenceModel`` instance to initiate our
 ``DynBatcher``:

--- a/fast_dynamic_batcher/dyn_batcher.py
+++ b/fast_dynamic_batcher/dyn_batcher.py
@@ -8,6 +8,7 @@ from ctypes import c_bool
 from threading import Event, Lock, Thread
 
 from fast_dynamic_batcher.dyn_prog_loop import _main_loop, _return_loop
+from fast_dynamic_batcher.errors import DynamicBatchIndexError
 from fast_dynamic_batcher.inference_template import InferenceModel
 from fast_dynamic_batcher.models import Task
 
@@ -89,10 +90,13 @@ class DynBatcher:
 
         :param input: The input which will be passed to the `infer` of the registered InferenceModel as the content of a Task.
         :type input: t.Any
+        :raises DynamicBatchIndexError: Error raised when something went wrong during batch processing.
         :return: The output of the InferenceModel's `infer` method.
         :rtype: t.Any
         """
         result = await asyncio.to_thread(self._process_batched, input)
+        if isinstance(result, DynamicBatchIndexError):
+            raise result
         return result
 
     def _process_batched(self, input: t.Any) -> t.Any:

--- a/fast_dynamic_batcher/errors.py
+++ b/fast_dynamic_batcher/errors.py
@@ -1,0 +1,18 @@
+class DynamicBatchIndexError(IndexError):
+    """
+    Error raised when the number of outputs returned by the infer function of a InferenceModel
+    differs from the number of inputs.
+    """
+
+    def __init__(self, message):
+        """
+        The DynamicBatchIndexError is used to propagate the cause of the Errors to users of the DynBatcher.
+
+        :param message: Message to be propagated back
+        :type message: str, optional
+        """
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self):
+        return f"DynamicBatchIndexError: {self.message}"

--- a/fast_dynamic_batcher/inference_template.py
+++ b/fast_dynamic_batcher/inference_template.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
-
-from fast_dynamic_batcher.models import Task
+from typing import Any
 
 
 class InferenceModel(ABC):
@@ -13,14 +12,14 @@ class InferenceModel(ABC):
     """
 
     @abstractmethod
-    def infer(self, tasks: list[Task]) -> list[Task]:
+    def infer(self, inputs: list[Any]) -> list[Any]:
         """
-        Abstract method that is used by the DynBatcher to process a batch of inputs. Use the tasks to create a batch for your machine learning model.
+        Abstract method that is used by the DynBatcher to process a batch of inputs.
 
 
-        :param tasks: A list of Tasks. The content of each task contains the input passed to the DynBatcher for batch processing.
-        :type tasks: list[Task]
-        :return: The outputs of the machine learning model as a list of tasks. The tasks should have the same ids as the inputs and the content of the task should be the processed content of the corresponding input task.
-        :rtype: list[Task]
+        :param inputs: A list of inputs your model can run as a single batch.
+        :type inputs: list[Any]
+        :return: The outputs of the machine learning model. The position of an output should correspond to the position of the input used to produce it.
+        :rtype: list[Any]
         """
         ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 repository = "https://github.com/JeffWigger/FastDynamicBatcher"
 homepage = "https://github.com/JeffWigger/FastDynamicBatcher"
 keywords = ["machine-learning", "batching"]
-# documentation = "https://python-poetry.org/docs/"
+documentation = "https://fastdynamicbatcher.readthedocs.io/en/latest/"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "~0.4.10"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 import time
 
 from contextlib import asynccontextmanager
+from typing import Any
 
 import pytest
 
@@ -11,16 +12,23 @@ from pydantic import BaseModel
 
 from fast_dynamic_batcher.dyn_batcher import DynBatcher
 from fast_dynamic_batcher.inference_template import InferenceModel
-from fast_dynamic_batcher.models import Task
 
 
 class TestModel(InferenceModel):
     def __init__(self):
         super().__init__()
 
-    def infer(self, tasks: list[Task]) -> list[Task]:
+    def infer(self, inputs: list[Any]) -> list[Any]:
         time.sleep(0.05)
-        return tasks
+        return inputs
+
+
+class ErrorTestModel(InferenceModel):
+    def __init__(self):
+        super().__init__()
+
+    def infer(self, inputs: list[Any]) -> list[Any]:
+        return inputs[0:-1]
 
 
 class Input(BaseModel):
@@ -50,3 +58,10 @@ def wrapped_app():
 
     yield app
     # dyn_batcher.stop()
+
+
+@pytest.fixture
+def dyn_batcher():
+    dyn_batcher = DynBatcher(ErrorTestModel, 8)
+    yield dyn_batcher
+    dyn_batcher.stop()

--- a/test/test_dyn_batcher_error.py
+++ b/test/test_dyn_batcher_error.py
@@ -1,0 +1,27 @@
+import asyncio
+
+import pytest
+
+from fast_dynamic_batcher.errors import DynamicBatchIndexError
+
+
+@pytest.mark.asyncio
+async def test_raised_errors_not_returned(dyn_batcher):
+    await_list = []
+    for i in range(5):
+        await_list.append(dyn_batcher.process_batched(i))
+    with pytest.raises(DynamicBatchIndexError) as exc_info:
+        await asyncio.gather(*await_list, return_exceptions=False)
+    assert exc_info.type is DynamicBatchIndexError
+    assert exc_info.value.message == "Dynamic batch of input size 5 produced 4."
+
+
+@pytest.mark.asyncio
+async def test_raised_errors_returned(dyn_batcher):
+    await_list = []
+    for i in range(5):
+        await_list.append(dyn_batcher.process_batched(i))
+    results = await asyncio.gather(*await_list, return_exceptions=True)
+
+    assert all([isinstance(res, DynamicBatchIndexError) for res in results])
+    assert all([res.message == "Dynamic batch of input size 5 produced 4." for res in results])


### PR DESCRIPTION
Simplifies how a InferenceModel is specified. Users do no longer have to return a List of Tasks.